### PR TITLE
Add tag pages and tags to blog posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.1",
       "dependencies": {
         "astro": "^5.3.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.3"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -4481,7 +4484,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   },
   "dependencies": {
     "astro": "^5.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3"
   }
 }

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -4,4 +4,5 @@
     <a href="/">Home</a>
     <a href="/about/">About</a>
     <a href="/blog/">Blog</a>
+    <a href="/tags/">Tags</a>
 </div>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -3,9 +3,35 @@ import BaseLayout from './BaseLayout.astro';
 const { frontmatter } = Astro.props;
 ---
 <BaseLayout pageTitle={frontmatter.title}>
-    <p>{frontmatter.pubDate.toString().slice(0,10)}</p>
     <p><em>{frontmatter.description}</em></p>
+    <p>{frontmatter.pubDate.toString().slice(0,10)}</p>
     <p>Written by: {frontmatter.author}</p>
     <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
+    <div class="tags">
+        <h3>Tags:</h3>
+        {frontmatter.tags.map((tag: string) => (
+        <p class="tag"><a href={`/tags/${tag}`}>{tag}</a></p>
+            ))}
+    </div>
+
     <slot />
 </BaseLayout>
+<style>
+    a {
+      color: #00539F;
+    }
+  
+    .tags {
+      display: flex;
+      flex-wrap: wrap;
+    }
+  
+    .tag {
+      margin: 0.25em;
+      border: dotted 1px #a1a1a1;
+      border-radius: .5em;
+      padding: .5em 1em;
+      font-size: 1.15em;
+      background-color: #F8FCFD;
+    }
+</style>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,28 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import BlogPost from '../../components/BlogPost.astro';
+
+export async function getStaticPaths() {
+  const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
+
+  const uniqueTags = [...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat())];
+
+  return uniqueTags.map((tag) => {
+    const filteredPosts = allPosts.filter((post: any) => post.frontmatter.tags.includes(tag));
+    return {
+        params: { tag },
+        props: { posts: filteredPosts },
+    };
+    });
+}
+
+const { tag } = Astro.params;
+const { posts } = Astro.props;
+const filteredPosts = posts.filter((post: any) => post.frontmatter.tags?.includes(tag));
+---
+<BaseLayout pageTitle={tag}>
+  <p>Posts tagged with {tag}</p>
+  <ul>
+    {posts.map((post: any) => <BlogPost url={post.url} title={post.frontmatter.title}/>)}
+  </ul>
+</BaseLayout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,33 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+const allPosts = Object.values(import.meta.glob('../posts/*.md', { eager: true }));
+const tags = [...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat())];
+
+const pageTitle = "Tags Page";
+---
+<BaseLayout pageTitle={pageTitle}>
+    <div class="tags">
+        {tags.map((tag) => (
+        <p class="tag"><a href={`/tags/${tag}`}>{tag}</a></p>
+            ))}
+    </div>
+    <style>
+        a {
+          color: #00539F;
+        }
+      
+        .tags {
+          display: flex;
+          flex-wrap: wrap;
+        }
+      
+        .tag {
+          margin: 0.25em;
+          border: dotted 1px #a1a1a1;
+          border-radius: .5em;
+          padding: .5em 1em;
+          font-size: 1.15em;
+          background-color: #F8FCFD;
+        }
+    </style>
+</BaseLayout>


### PR DESCRIPTION
This change adds support for tags in blog posts:
* Tag component 
* Tags page
* Routing for /tags
* In-page tags and styling

On the Tags page, each tag is clickable and takes you to the page for that tag, which shows each blog post tagged with the tag. On a blog post, you can click the tag for the same experience.